### PR TITLE
Force version upgrade of qdox

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,15 @@ dependencies {
     implementation("org.codehaus.plexus:plexus-velocity:1.1.8") {
         because("it is needed to generate the help mojo")
     }
+    constraints {
+        implementation("com.thoughtworks.qdox:qdox") {
+            version {
+                require("2.0-M9")
+                prefer("2.0.0")
+            }
+            because("we need the fix for https://github.com/paul-hammant/qdox/issues/43")
+        }
+    }
 
     testImplementation("org.spockframework:spock-core:1.3-groovy-2.5")
     testFixturesImplementation("junit:junit:4.12")

--- a/src/test/groovy/de/benediktritter/maven/plugin/development/MavenPluginDevelopmentPluginFuncTest.groovy
+++ b/src/test/groovy/de/benediktritter/maven/plugin/development/MavenPluginDevelopmentPluginFuncTest.groovy
@@ -123,6 +123,23 @@ class MavenPluginDevelopmentPluginFuncTest extends AbstractPluginFuncTest {
         result.output.contains("ArtifactIds of the form maven-___-plugin are reserved for plugins of the maven team. Please change the plugin artifactId to the format ___-maven-plugin.")
     }
 
+    def "works even if weird enums are present"() {
+        given:
+        file("src/main/java/TypedEnum.java") << """
+        import java.util.List;
+        public enum TypedEnum {
+            ENUM_VALUE {
+                private <T> List<T> genericMethod(List<T> list) {
+                    return list;
+                }
+            }
+        }
+        """
+
+        expect:
+        run("generateMavenPluginDescriptor")
+    }
+
     def "generates a plugin and help descriptor for mojos in the main source set"() {
         given:
         buildFile << """


### PR DESCRIPTION
The qdox library is used by maven-plugin-tools in order to analyze
JavaDocs. The qdox version brought in by maven-plugin-tools:3.6.0 is
2.0-M5. However there was a bug that caused NullPointerExceptions when
enum values have methods with generics.
We now require at least the release that has the fix and prefer the
latest currently available release.