### PR TITLE
Extract mojos from subprojects

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -1,5 +1,10 @@
 # 0.2.0 - TBA
 
+## New Features
+
+* Add support for mojos from other projects
+  https://github.com/britter/maven-plugin-development/issues/3
+
 ## Bug Fixes
 
 * Force version upgrade of qdox

--- a/src/main/kotlin/de/benediktritter/maven/plugin/development/MavenPluginDevelopmentPlugin.kt
+++ b/src/main/kotlin/de/benediktritter/maven/plugin/development/MavenPluginDevelopmentPlugin.kt
@@ -59,8 +59,9 @@ class MavenPluginDevelopmentPlugin : Plugin<Project> {
         // TODO declare help properties as input
         val generateTask = tasks.register<GenerateMavenPluginDescriptorTask>("generateMavenPluginDescriptor") {
             classesDirs.set(extension.pluginSourceSet.map { it.output.classesDirs })
-            sourcesDirs.set(extension.pluginSourceSet.map { it.allSource.sourceDirectories })
+            sourcesDirs.set(extension.pluginSourceSet.map { it.java.sourceDirectories })
             javaClassesDir.set(extension.pluginSourceSet.flatMap { it.java.classesDirectory })
+            mojoDependencies.set(project.configurations["runtimeClasspath"])
             outputDirectory.set(descriptorDir)
             pluginDescriptor.set(project.provider {
                 MavenPluginDescriptor(

--- a/src/test/groovy/de/benediktritter/maven/plugin/development/AbstractPluginFuncTest.groovy
+++ b/src/test/groovy/de/benediktritter/maven/plugin/development/AbstractPluginFuncTest.groovy
@@ -16,7 +16,7 @@
 
 package de.benediktritter.maven.plugin.development
 
-import de.benediktritter.maven.plugin.development.fixtures.Workspace
+import de.benediktritter.maven.plugin.development.fixtures.TestRootProject
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import spock.lang.Specification
@@ -27,28 +27,11 @@ abstract class AbstractPluginFuncTest extends Specification {
 
     @Rule
     @Delegate
-    Workspace workspace
+    TestRootProject project
 
     void setup() {
         settingsFile << "rootProject.name=\"touch-maven-plugin\""
-        buildFile << """
-            plugins {
-                id 'java'
-                id 'de.benediktritter.maven-plugin-development'
-            }
-
-            group "org.example"
-            description "A maven plugin with a mojo that can touch it!"
-            version "1.0.0"
-
-            repositories {
-                mavenCentral()
-            }
-            dependencies {
-                implementation 'org.apache.maven:maven-plugin-api:3.6.3'
-                implementation 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0'
-            }
-        """
+        withMavenPluginBuildConfiguration()
     }
 
     def run(String... args) {
@@ -57,7 +40,7 @@ abstract class AbstractPluginFuncTest extends Specification {
                 .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0)
                 .withPluginClasspath()
                 .withArguments([*args, "-s"])
-                .withProjectDir(workspace.root)
+                .withProjectDir(project.projectDir)
 
         runner.build()
     }

--- a/src/test/groovy/de/benediktritter/maven/plugin/development/MavenUsageFuncTest.groovy
+++ b/src/test/groovy/de/benediktritter/maven/plugin/development/MavenUsageFuncTest.groovy
@@ -171,6 +171,6 @@ class MavenUsageFuncTest extends AbstractPluginFuncTest {
   </build>
 </project>
         """
-        workspace.root
+        project.projectDir
     }
 }

--- a/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/TestRootProject.groovy
+++ b/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/TestRootProject.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Benedikt Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.benediktritter.maven.plugin.development.fixtures
+
+import org.junit.rules.ExternalResource
+import org.junit.rules.TemporaryFolder
+
+class TestRootProject extends ExternalResource implements TestProject {
+
+    private TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Lazy DescriptorFile pluginDescriptor = pluginDescriptor()
+
+    @Lazy DescriptorFile helpDescriptor = helpDescriptor()
+
+    @Override
+    void before() {
+        temporaryFolder.create()
+    }
+
+    @Override
+    void after() {
+        temporaryFolder.delete()
+    }
+
+    File getProjectDir() {
+        temporaryFolder.root
+    }
+
+    TestProject subproject(String projectName, @DelegatesTo(TestProject) Closure<TestProject> configureProject) {
+        settingsFile << """
+            include '$projectName'
+        """
+        def sub = new TestSubproject(dir(projectName))
+        configureProject.delegate = sub
+        configureProject.call(sub)
+        sub
+    }
+}

--- a/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/TestSubproject.groovy
+++ b/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/TestSubproject.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Benedikt Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.benediktritter.maven.plugin.development.fixtures
+
+class TestSubproject implements TestProject {
+
+    File projectDir
+
+    @Lazy DescriptorFile pluginDescriptor = pluginDescriptor()
+
+    @Lazy DescriptorFile helpDescriptor = helpDescriptor()
+
+    TestSubproject(File projectDir) {
+        this.projectDir = projectDir
+    }
+}


### PR DESCRIPTION
The generateMavenPluginDescriptor task now searches configurations[runtimeClasspath]
for mojo implementations in other subprojects of a multi project build. If mojos are
found they are added to the resulting plugin descriptor.

Resolves #3