### PR TITLE
Apply JavaPlugin instead of JavaBasePlugin

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -1,3 +1,10 @@
+# 0.2.1 - tba
+
+## Bug Fixes
+
+* Build fails when `java` plugin is not applied explicitly
+  https://github.com/britter/maven-plugin-development/issues/19
+
 # 0.2.0 - 2020-04-16
 
 ## New Features

--- a/src/main/kotlin/de/benediktritter/maven/plugin/development/MavenPluginDevelopmentPlugin.kt
+++ b/src/main/kotlin/de/benediktritter/maven/plugin/development/MavenPluginDevelopmentPlugin.kt
@@ -23,14 +23,16 @@ import de.benediktritter.maven.plugin.development.task.GenerateMavenPluginDescri
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.register
 
 class MavenPluginDevelopmentPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
-        pluginManager.apply(JavaBasePlugin::class)
+        pluginManager.apply(JavaPlugin::class)
 
         val pluginOutputDirectory = layout.buildDirectory.dir("mavenPlugin")
         val descriptorDir = pluginOutputDirectory.map { it.dir("descriptor") }

--- a/src/test/groovy/de/benediktritter/maven/plugin/development/BuildLifecycleFuncTest.groovy
+++ b/src/test/groovy/de/benediktritter/maven/plugin/development/BuildLifecycleFuncTest.groovy
@@ -21,11 +21,12 @@ import spock.lang.Unroll
 
 class BuildLifecycleFuncTest extends AbstractPluginFuncTest {
 
+    def setup() {
+        javaMojo()
+    }
+
     @Unroll
     def "task is executed when #task lifecycle task is executed"() {
-        given:
-        javaMojo()
-
         when:
         def result = run(task)
 
@@ -38,5 +39,13 @@ class BuildLifecycleFuncTest extends AbstractPluginFuncTest {
 
         where:
         task << ["jar", "build"]
+    }
+
+    def "works without applying other plugins"() {
+        when:
+        buildFile.text = buildFile.text.replace("id 'java'", "")
+
+        then:
+        run("build")
     }
 }


### PR DESCRIPTION
Only the former created the main sourceSet which is needed to setup the
pluginSourceSet convention.

Fixes #19