### PR TITLE
Fix typing

### DIFF
--- a/subprojects/documentation/src/docs/asciidoc/parts/release-history.adoc
+++ b/subprojects/documentation/src/docs/asciidoc/parts/release-history.adoc
@@ -4,10 +4,14 @@
 
 Release date: tba
 
+=== New Features
+
+* Tasks provide proper descriptions ({gh-issue}22[#22])
+
 === Bug Fixes
 
 * Build fails when `java` plugin is not applied explicitly ({gh-issue}19[#19])
-* Tasks provide proper descriptions ({gh-issue}22[#22])
+* Typing of `parameters` API is incorrect ({gh-issue}23[#23])
 
 == 0.2.0
 

--- a/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/MavenMojoParametersSpec.kt
+++ b/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/MavenMojoParametersSpec.kt
@@ -29,7 +29,7 @@ interface MavenMojoParametersSpec {
 
     fun parameter(name: String, type: String, configure: Action<in MavenMojoParameter>)
 
-    fun parameter(name: String, type: Class<Any>)
+    fun parameter(name: String, type: Class<*>)
 
-    fun parameter(name: String, type: Class<Any>, configure: Action<in MavenMojoParameter>)
+    fun parameter(name: String, type: Class<*>, configure: Action<in MavenMojoParameter>)
 }

--- a/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/internal/DefaultMavenMojo.kt
+++ b/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/internal/DefaultMavenMojo.kt
@@ -95,11 +95,11 @@ open class DefaultMavenMojo(@get:Input val name: String) : MavenMojo, MavenMojoP
         parameters.add(parameter)
     }
 
-    override fun parameter(name: String, type: Class<Any>) {
+    override fun parameter(name: String, type: Class<*>) {
         parameter(name, type.name)
     }
 
-    override fun parameter(name: String, type: Class<Any>, configure: Action<in MavenMojoParameter>) {
+    override fun parameter(name: String, type: Class<*>, configure: Action<in MavenMojoParameter>) {
         parameter(name, type.name, configure)
     }
 }


### PR DESCRIPTION
Having a Class<Any> typing was not usable from Kotlin DSL. Change it to
Class<*> so it can actually be used.

Fixes #23