### PR TITLE
Fix up to date checking for mojo dependencies

### DIFF
--- a/subprojects/documentation/src/docs/asciidoc/parts/release-history.adoc
+++ b/subprojects/documentation/src/docs/asciidoc/parts/release-history.adoc
@@ -1,5 +1,13 @@
 = Release History
 
+== 0.3.2
+
+Release date: tba
+
+=== Bug fixes
+
+* Descriptor generation is up to date although mojo dependency changed ({gh-issue}13[#13])
+
 == 0.3.1
 
 Release date: 2020-09-27

--- a/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
+++ b/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
@@ -51,7 +51,7 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
     @get:Input
     abstract val sourcesDirs: Property<FileCollection>
 
-    @get:Input
+    @get:Internal
     abstract val mojoDependencies: Property<Configuration>
 
     @get:Nested
@@ -163,5 +163,8 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
     private fun getUpstreamProjects() = mojoDependencies.get().dependencies
                 .filterIsInstance<ProjectDependency>()
                 .map { it.dependencyProject }
+
+    @InputFiles @PathSensitive(PathSensitivity.NAME_ONLY)
+    fun getMojoProjectSourceDirectories() = getUpstreamProjects().flatMap { it.the<SourceSetContainer>()["main"].java.sourceDirectories }
 }
 

--- a/subprojects/plugin/src/test/groovy/de/benediktritter/maven/plugin/development/PluginDescriptorGenerationFuncTest.groovy
+++ b/subprojects/plugin/src/test/groovy/de/benediktritter/maven/plugin/development/PluginDescriptorGenerationFuncTest.groovy
@@ -228,27 +228,14 @@ class PluginDescriptorGenerationFuncTest extends AbstractPluginFuncTest {
 
     def "finds mojos in project dependencies"() {
         given:
-        settingsFile.text = "rootProject.name = 'root-project'"
-        buildFile.text = ""
-        subproject("touch-mojo") { project ->
-            project.withMavenPluginBuildConfiguration(false)
-            project.javaMojo()
-        }
+        multiProjectSetup()
         subproject("create-mojo") { project ->
             project.withMavenPluginBuildConfiguration(false)
             project.javaMojo("main", "create")
         }
         def pluginProject = subproject("plugin") { project ->
             project.buildFile << """
-                plugins {
-                    id 'java'
-                    id 'de.benediktritter.maven-plugin-development'
-                }
-                repositories {
-                    mavenCentral()
-                }
                 dependencies {
-                    mojo project(":touch-mojo") 
                     implementation project(":create-mojo") 
                 }
             """

--- a/subprojects/plugin/src/test/groovy/de/benediktritter/maven/plugin/development/UpToDateCheckingFuncTest.groovy
+++ b/subprojects/plugin/src/test/groovy/de/benediktritter/maven/plugin/development/UpToDateCheckingFuncTest.groovy
@@ -43,4 +43,26 @@ class UpToDateCheckingFuncTest extends AbstractPluginFuncTest {
         result.task(":generateMavenPluginHelpMojoSources").outcome == TaskOutcome.UP_TO_DATE
         result.task(":generateMavenPluginDescriptor").outcome == TaskOutcome.UP_TO_DATE
     }
+
+    def "is not up to date if mojo dependency changes"() {
+        given:
+        multiProjectSetup()
+
+        when:
+        def result = run("build")
+
+        then:
+        result.task(":plugin:generateMavenPluginDescriptor").outcome == TaskOutcome.SUCCESS
+
+        when:
+        subproject("touch-mojo") { project ->
+            project.file("src/main/java/org/example/TouchMojo.java").replace("LifecyclePhase.PROCESS_SOURCES", "LifecyclePhase.COMPILE")
+        }
+
+        and:
+        result = run("build")
+
+        then:
+        result.task(":plugin:generateMavenPluginDescriptor").outcome == TaskOutcome.SUCCESS
+    }
 }

--- a/subprojects/plugin/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/FileExtensions.groovy
+++ b/subprojects/plugin/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/FileExtensions.groovy
@@ -40,4 +40,9 @@ class FileExtensions {
     static boolean contains(File self, DescriptorFile descriptor) {
         contains(self, descriptor.path)
     }
+
+    static void replace(File self, String text, String replacement) {
+        def oldText = self.text
+        self.text = oldText.replace(text, replacement)
+    }
 }


### PR DESCRIPTION
Java sources of project dependencies in the mojo configuration are now correctly
tracked as input files.

Fixes #13