### PR TITLE
Simplify test

### DIFF
--- a/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/PluginDescriptorGenerationFuncTest.groovy
+++ b/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/PluginDescriptorGenerationFuncTest.groovy
@@ -229,17 +229,7 @@ class PluginDescriptorGenerationFuncTest extends AbstractPluginFuncTest {
     def "finds mojos in project dependencies"() {
         given:
         multiProjectSetup()
-        subproject("create-mojo") { project ->
-            project.withMavenPluginBuildConfiguration(false)
-            project.javaMojo("main", "create")
-        }
-        def pluginProject = subproject("plugin") { project ->
-            project.buildFile << """
-                dependencies {
-                    implementation project(":create-mojo") 
-                }
-            """
-        }
+        def pluginProject = subproject("plugin")
 
         when:
         run(":plugin:build")


### PR DESCRIPTION
This test unnecessarily duplicates setup thats already created
by the multiProjectSetup() method.
