### PR TITLE
Move test to dedicated issue spec

### DIFF
--- a/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/PluginDescriptorGenerationFuncTest.groovy
+++ b/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/PluginDescriptorGenerationFuncTest.groovy
@@ -121,23 +121,6 @@ class PluginDescriptorGenerationFuncTest extends AbstractPluginFuncTest {
         result.output.contains("ArtifactIds of the form maven-___-plugin are reserved for plugins of the maven team. Please change the plugin artifactId to the format ___-maven-plugin.")
     }
 
-    def "works even if weird enums are present"() {
-        given:
-        file("src/main/java/TypedEnum.java") << """
-        import java.util.List;
-        public enum TypedEnum {
-            ENUM_VALUE {
-                private <T> List<T> genericMethod(List<T> list) {
-                    return list;
-                }
-            }
-        }
-        """
-
-        expect:
-        run("generateMavenPluginDescriptor")
-    }
-
     def "generates a plugin and help descriptor for mojos in the main source set"() {
         given:
         buildFile << """

--- a/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue9FuncTest.groovy
+++ b/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue9FuncTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Benedikt Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.benediktritter.maven.plugin.development.issues
+
+import de.benediktritter.maven.plugin.development.AbstractPluginFuncTest
+import spock.lang.Issue
+
+@Issue("https://github.com/britter/maven-plugin-development/pull/9")
+class Issue9FuncTest extends AbstractPluginFuncTest {
+
+    def "works even if weird enums are present"() {
+        given:
+        file("src/main/java/TypedEnum.java") << """
+        import java.util.List;
+        public enum TypedEnum {
+            ENUM_VALUE {
+                private <T> List<T> genericMethod(List<T> list) {
+                    return list;
+                }
+            }
+        }
+        """
+
+        expect:
+        run("generateMavenPluginDescriptor")
+    }
+}


### PR DESCRIPTION
The test for #9 is quite specific so it's moved to a dedicated class to
not confuse readers of PluginDescriptorGenerationFuncTest.
