### PR TITLE
Extract mojo meta data from parent classes in referenced modules

### DIFF
--- a/subprojects/documentation/src/docs/asciidoc/parts/plugin-usage.adoc
+++ b/subprojects/documentation/src/docs/asciidoc/parts/plugin-usage.adoc
@@ -31,8 +31,9 @@ include::{snippets-path}/help-mojo/kotlin/build.gradle.kts[tags=help-mojo]
 
 == Extracting mojos from other subprojects
 
-The plugin will create a configuration called `mojo` and add it to the project.
-All project dependencies added to this configuration will be searched for mojo implementations.
+The plugin searches the compile classpath for mojo implementations and extracts plugin descriptors
+from all _project_ dependencies. This means that mojos are not scanned in binary dependencies, only
+in dependencies that are build from modules of the build that applies this plugin.
 
 [source.multi-language-sample,groovy]
 ----

--- a/subprojects/documentation/src/docs/asciidoc/parts/release-history.adoc
+++ b/subprojects/documentation/src/docs/asciidoc/parts/release-history.adoc
@@ -1,12 +1,19 @@
 = Release History
 
-== 0.3.2
+== 0.4.0
 
 Release date: tba
 
 === Bug fixes
 
 * Descriptor generation is up to date although mojo dependency changed ({gh-issue}13[#13])
+* `@Parameter` in abstract classes in other modules are ignored ({gh-issue}73[#73])
+
+=== Breaking changes
+
+* The `mojo` configuration was removed without replacement.
+  The plugin now searches the compile classpath instead.
+* Property `mojoDependencies` dropped from `GenerateMavenPluginDescriptorTask` without replacement.
 
 == 0.3.1
 

--- a/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue73FuncTest.groovy
+++ b/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue73FuncTest.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Benedikt Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.benediktritter.maven.plugin.development.issues
+
+import de.benediktritter.maven.plugin.development.AbstractPluginFuncTest
+import de.benediktritter.maven.plugin.development.fixtures.TestProject
+import spock.lang.Issue
+
+@Issue("https://github.com/britter/maven-plugin-development/issues/73")
+class Issue73FuncTest extends AbstractPluginFuncTest {
+
+    def "extracts properties from base mojos defined outside the project"() {
+        given:
+        subproject("base-mojo") { project ->
+            project.buildFile << """
+                plugins {
+                    id 'java'
+                }
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    implementation 'org.apache.maven:maven-plugin-api:3.6.3'
+                    implementation 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0'
+                }
+            """
+            project.file("src/main/java/sample/lib/AbstractNameMojo.java") << """
+                package sample.lib;
+                
+                import org.apache.maven.plugin.AbstractMojo;
+                import org.apache.maven.plugins.annotations.Parameter;
+                
+                public abstract class AbstractNameMojo extends AbstractMojo {
+                
+                  @Parameter(property = "name")
+                  private String name;
+                
+                  public String getName() {
+                    return name;
+                  }
+                }
+            """
+        }
+        TestProject mojoProject = subproject("greeting-mojo") { project ->
+            project.withMavenPluginBuildConfiguration()
+            project.buildFile << """
+                dependencies.implementation project(':base-mojo')
+            """
+            project.file("src/main/java/sample/plugin/GreetingMojo.java") << """
+                package sample.plugin;
+                
+                import org.apache.maven.plugin.MojoExecutionException;
+                import org.apache.maven.plugins.annotations.Mojo;
+                import org.apache.maven.plugins.annotations.Parameter;
+                import sample.lib.AbstractNameMojo;
+                
+                /**
+                 * Says "Hi" to the user.
+                 */
+                @Mojo(name = "sayhi")
+                public class GreetingMojo extends AbstractNameMojo {
+                
+                  @Parameter(property = "greeting")
+                  private String greeting;
+                
+                  public String getGreeting() {
+                    return greeting;
+                  }
+                
+                  @Override
+                  public void execute() throws MojoExecutionException {
+                    getLog().info("GreetingMojo: " + getGreeting() + " " + getName());
+                  }
+                }
+            """
+        }
+
+        when:
+        run("build")
+
+        then:
+        mojoProject.pluginDescriptor.getMojo("sayhi").parameters.contains("name")
+    }
+}

--- a/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue73FuncTest.groovy
+++ b/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue73FuncTest.groovy
@@ -59,7 +59,7 @@ class Issue73FuncTest extends AbstractPluginFuncTest {
         TestProject mojoProject = subproject("greeting-mojo") { project ->
             project.withMavenPluginBuildConfiguration()
             project.buildFile << """
-                dependencies.mojo project(':base-mojo')
+                dependencies.implementation project(':base-mojo')
             """
             project.file("src/main/java/sample/plugin/GreetingMojo.java") << """
                 package sample.plugin;

--- a/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue73FuncTest.groovy
+++ b/subprojects/plugin/src/compatTest/groovy/de/benediktritter/maven/plugin/development/issues/Issue73FuncTest.groovy
@@ -17,6 +17,7 @@
 package de.benediktritter.maven.plugin.development.issues
 
 import de.benediktritter.maven.plugin.development.AbstractPluginFuncTest
+import de.benediktritter.maven.plugin.development.fixtures.DescriptorFile
 import de.benediktritter.maven.plugin.development.fixtures.TestProject
 import spock.lang.Issue
 
@@ -58,7 +59,7 @@ class Issue73FuncTest extends AbstractPluginFuncTest {
         TestProject mojoProject = subproject("greeting-mojo") { project ->
             project.withMavenPluginBuildConfiguration()
             project.buildFile << """
-                dependencies.implementation project(':base-mojo')
+                dependencies.mojo project(':base-mojo')
             """
             project.file("src/main/java/sample/plugin/GreetingMojo.java") << """
                 package sample.plugin;
@@ -90,9 +91,9 @@ class Issue73FuncTest extends AbstractPluginFuncTest {
         }
 
         when:
-        run("build")
+        run(":greeting-mojo:build")
 
         then:
-        mojoProject.pluginDescriptor.getMojo("sayhi").parameters.contains("name")
+        mojoProject.pluginDescriptor.getMojo("sayhi").parameters.contains(new DescriptorFile.ParameterDeclaration("name", String, "", false, true, ""))
     }
 }

--- a/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
+++ b/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
@@ -106,14 +106,6 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
                 }
                 scanner.populatePluginDescriptor(pluginToolsRequest)
             }
-            getUpstreamProjects().forEach {
-                val main = it.the<SourceSetContainer>()["main"]
-                main.output.classesDirs.forEach { classesDir ->
-                    val mavenProject = mavenProject(it, main.java.sourceDirectories, classesDir)
-                    val pluginToolsRequest = createPluginToolsRequest(mavenProject, pluginDescriptor)
-                    scanner.populatePluginDescriptor(pluginToolsRequest)
-                }
-            }
             addAdditionalMojos(pluginDescriptor)
         }
     }

--- a/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
+++ b/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
@@ -31,15 +31,12 @@ import org.apache.maven.project.artifact.ProjectArtifact
 import org.apache.maven.tools.plugin.ExtendedMojoDescriptor
 import org.apache.maven.tools.plugin.generator.PluginDescriptorGenerator
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.the
 import java.io.File
 
 @CacheableTask
@@ -54,8 +51,8 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
     @get:Input
     abstract val sourcesDirs: Property<FileCollection>
 
-    @get:Internal
-    abstract val mojoDependencies: Property<Configuration>
+    @get:Nested
+    abstract val upstreamProjects: ListProperty<UpstreamProjectDescriptor>
 
     @get:Nested
     abstract val additionalMojos: SetProperty<DefaultMavenMojo>
@@ -94,22 +91,23 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
             classesDirs.get().forEach { classesDir ->
                 val mavenProject = mavenProject(project, sourcesDirs.get(), classesDir)
                 val pluginToolsRequest = createPluginToolsRequest(mavenProject, pluginDescriptor)
-                getUpstreamProjects().forEach {
-                    val main = it.the<SourceSetContainer>()["main"]
-                    main.output.classesDirs.map { classesDir ->
-                        val artifact = DefaultArtifact("${it.group}", it.name, "${it.version}", "compile", "jar", null, DefaultArtifactHandler()).also { artifact ->
+                // process upstream projects in order to scan base classes
+                upstreamProjects.get().forEach {
+                    it.classesDirs.map { classesDir ->
+                        val artifact = DefaultArtifact(it.group, it.name,
+                            it.version, "compile", "jar", null, DefaultArtifactHandler()).also { artifact ->
                             artifact.file = classesDir
                         }
                         pluginToolsRequest.dependencies.add(artifact)
-                        mavenProject.addProjectReference(mavenProject(it, main.java.sourceDirectories, classesDir))
+                        mavenProject.addProjectReference(mavenProject(it.group, it.name, it.version, it.sourceDirectories, classesDir))
                     }
                 }
                 scanner.populatePluginDescriptor(pluginToolsRequest)
             }
-            getUpstreamProjects().forEach {
-                val main = it.the<SourceSetContainer>()["main"]
-                main.output.classesDirs.forEach { classesDir ->
-                    val mavenProject = mavenProject(it, main.java.sourceDirectories, classesDir)
+            // process upstream projects again in order to find mojo implementations
+            upstreamProjects.get().forEach {
+                it.classesDirs.forEach { classesDir ->
+                    val mavenProject = mavenProject(it.group, it.name, it.version, it.sourceDirectories, classesDir)
                     val pluginToolsRequest = createPluginToolsRequest(mavenProject, pluginDescriptor)
                     scanner.populatePluginDescriptor(pluginToolsRequest)
                 }
@@ -158,11 +156,20 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
         }
     }
 
-    private fun mavenProject(project: Project, sourcesDirs: FileCollection, outputDirectory: File): MavenProject {
+    private fun mavenProject(project: Project, sourcesDirs: FileCollection, outputDirectory: File): MavenProject =
+        mavenProject(project.group.toString(), project.name, project.version.toString(), sourcesDirs, outputDirectory)
+
+    private fun mavenProject(
+        groupId: String,
+        artifactId: String,
+        version: String,
+        sourcesDirs: FileCollection,
+        outputDirectory: File
+    ): MavenProject {
         return MavenProject().also {
-            it.groupId = project.group.toString()
-            it.artifactId = project.name
-            it.version = project.version.toString()
+            it.groupId = groupId
+            it.artifactId = artifactId
+            it.version = version
             it.artifact = ProjectArtifact(it)
             it.build = Build().also { b ->
                 b.outputDirectory = outputDirectory.absolutePath
@@ -172,12 +179,5 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
             sourcesDirs.forEach { dir -> it.addCompileSourceRoot(dir.absolutePath) }
         }
     }
-
-    private fun getUpstreamProjects() = mojoDependencies.get().dependencies
-                .filterIsInstance<ProjectDependency>()
-                .map { it.dependencyProject }
-
-    @InputFiles @PathSensitive(PathSensitivity.NAME_ONLY)
-    fun getMojoProjectSourceDirectories() = getUpstreamProjects().flatMap { it.the<SourceSetContainer>()["main"].java.sourceDirectories }
 }
 

--- a/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
+++ b/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/GenerateMavenPluginDescriptorTask.kt
@@ -106,6 +106,14 @@ abstract class GenerateMavenPluginDescriptorTask : AbstractMavenPluginDevelopmen
                 }
                 scanner.populatePluginDescriptor(pluginToolsRequest)
             }
+            getUpstreamProjects().forEach {
+                val main = it.the<SourceSetContainer>()["main"]
+                main.output.classesDirs.forEach { classesDir ->
+                    val mavenProject = mavenProject(it, main.java.sourceDirectories, classesDir)
+                    val pluginToolsRequest = createPluginToolsRequest(mavenProject, pluginDescriptor)
+                    scanner.populatePluginDescriptor(pluginToolsRequest)
+                }
+            }
             addAdditionalMojos(pluginDescriptor)
         }
     }

--- a/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/UpstreamProjectDescriptor.kt
+++ b/subprojects/plugin/src/main/kotlin/de/benediktritter/maven/plugin/development/task/UpstreamProjectDescriptor.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Benedikt Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.benediktritter.maven.plugin.development.task
+
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.CompileClasspath
+import org.gradle.api.tasks.IgnoreEmptyDirectories
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.NormalizeLineEndings
+
+data class UpstreamProjectDescriptor(
+    @get:Input val group: String,
+    @get:Input val name: String,
+    @get:Input val version: String,
+    @get:[InputFiles CompileClasspath] val classesDirs: FileCollection,
+    @get:[InputFiles PathSensitive(PathSensitivity.RELATIVE) IgnoreEmptyDirectories NormalizeLineEndings] val sourceDirectories: FileCollection
+)

--- a/subprojects/plugin/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/TestRootProject.groovy
+++ b/subprojects/plugin/src/testFixtures/groovy/de/benediktritter/maven/plugin/development/fixtures/TestRootProject.groovy
@@ -74,7 +74,7 @@ class TestRootProject extends ExternalResource implements TestProject {
                     mavenCentral()
                 }
                 dependencies {
-                    mojo project(":touch-mojo") 
+                    implementation project(":touch-mojo") 
                 }
             """
         }


### PR DESCRIPTION
The extraction now also finds definitions in mojo superclasses that are
defined in project dependencies. Maven plugin tools first find mojo classes from
all dependencies on the PluginToolsRequest. Then the origin of each found class
is determined by first looking at referenced reactor projects and then trying to
download sources jar.

For this to work when running in Gradle context the code needs to mimic more
of the Maven model:

- for each upsource project a referenced Maven project is added to the
  main Maven project
- for each upsource project classes dir an artifact with coordinates
  matching the referenced Maven project is added to the dependency list
  of the PluginToolsRequest

One issue with this is that a Gradle project may have several classes
dirs while a Maven project only has a single classes file.

As part of this the behavior of the plugin was changed: It now scans the
compile classpath instead of adding a dedicated configuration.

Fixes #73 