### PR TITLE
Manage plugin versions in version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,3 +24,10 @@ exemplar-sampleCheck = { module = "org.gradle.exemplar:samples-check", version =
 [bundles]
 mavenPluginTools-deps = ["mavenPluginTools-api", "mavenPluginTools-annotations", "mavenPluginTools-java", "mavenPluginTools-generators"]
 spock = ["spock-core", "spock-junit4"]
+
+[plugins]
+asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "3.3.2" }
+gitPublish = { id = "org.ajoberstar.git-publish", version = "3.0.0" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version = "1.4.10" }
+pluginPublish = { id = "com.gradle.plugin-publish", version = "1.1.0" }
+stutter = { id = "org.ajoberstar.stutter", version = "0.6.0" }

--- a/subprojects/documentation/build.gradle.kts
+++ b/subprojects/documentation/build.gradle.kts
@@ -16,8 +16,8 @@
 
 plugins {
     id("groovy")
-    id("org.asciidoctor.jvm.convert") version "3.3.2"
-    id("org.ajoberstar.git-publish") version "3.0.0"
+    alias(libs.plugins.asciidoctor)
+    alias(libs.plugins.gitPublish)
 }
 
 dependencies {

--- a/subprojects/plugin/build.gradle.kts
+++ b/subprojects/plugin/build.gradle.kts
@@ -153,7 +153,7 @@ publishing {
 if (!hasProperty("release")) {
     val pluginUnderTestMetadata by tasks.existing(PluginUnderTestMetadata::class)
 
-    val publication = configurations.create("pluginUnderTestMetadata") {
+    configurations.create("pluginUnderTestMetadata") {
         isCanBeConsumed = true
         isCanBeResolved = false
         outgoing.artifact(pluginUnderTestMetadata.flatMap { it.outputDirectory })

--- a/subprojects/plugin/build.gradle.kts
+++ b/subprojects/plugin/build.gradle.kts
@@ -20,9 +20,9 @@ plugins {
     `maven-publish`
     groovy
     idea
-    id("org.jetbrains.kotlin.jvm") version "1.4.10"
-    id("com.gradle.plugin-publish") version "1.1.0"
-    id("org.ajoberstar.stutter") version "0.6.0"
+    alias(libs.plugins.kotlin)
+    alias(libs.plugins.pluginPublish)
+    alias(libs.plugins.stutter)
 }
 
 group = "de.benediktritter"

--- a/subprojects/plugin/build.gradle.kts
+++ b/subprojects/plugin/build.gradle.kts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 plugins {
-    `java-gradle-plugin`
-    `java-test-fixtures`
+    id("groovy")
+    id("idea")
+    id("java-gradle-plugin")
+    id("java-test-fixtures")
+    id("maven-publish")
     `kotlin-dsl`
-    `maven-publish`
-    groovy
-    idea
     alias(libs.plugins.kotlin)
     alias(libs.plugins.pluginPublish)
     alias(libs.plugins.stutter)

--- a/subprojects/plugin/build.gradle.kts
+++ b/subprojects/plugin/build.gradle.kts
@@ -78,8 +78,8 @@ stutter {
 idea {
     project {
         module {
-            testSourceDirs.addAll(sourceSets["compatTest"].allSource.sourceDirectories.files)
-            testResourceDirs.addAll(sourceSets["compatTest"].resources.sourceDirectories.files)
+            testSources.from(sourceSets["compatTest"].allSource.sourceDirectories)
+            testResources.from(sourceSets["compatTest"].resources.sourceDirectories)
         }
     }
 }


### PR DESCRIPTION
- Manage plugin versions in version catalog
- Consistently use id(plugin) to reference core plugins
- Fix deprecation
- Fix build warning
