### PR TITLE
Remove repository filters for exemplar

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,15 +21,6 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        exclusiveContent {
-            forRepository {
-                maven(url = uri("https://repo.gradle.org/gradle/libs"))
-            }
-            filter {
-                includeModule("org.gradle", "sample-check")
-                includeModule("org.gradle", "sample-discovery")
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Exemplar is now published under a new group ID to maven central
so we don't need this filter anymore.
