### PR TITLE
ci: fix docs deployment by using asciidoctorAll task

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           build-scan-terms-of-use-url: https://gradle.com/help/legal-terms-of-use
           build-scan-terms-of-use-agree: yes
-      - run: "./gradlew :asciidoctor --no-configuration-cache"
+      - run: "./gradlew asciidoctorAll"
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: "./build/docs/asciidoc"
+          path: "./build/docs/asciidoc/html"
 
   deploy:
     environment:


### PR DESCRIPTION
The Asciidoctor Gradle setup no longer exposes a single 'asciidoctor'
task; it now produces 'asciidoctorHtml' plus an aggregate 'asciidoctorAll',
with HTML output moved to build/docs/asciidoc/html. The gh-pages workflow
still called ':asciidoctor', which now fails as ambiguous.

Mirror the migration already applied to the other gradlex repos.
